### PR TITLE
Port to python3

### DIFF
--- a/downgrade_elf.py
+++ b/downgrade_elf.py
@@ -1675,10 +1675,10 @@ with open(output_file_path_fixed, 'r+b') as f:
 					offset = 0
 
 					while offset < phdr.file_size:
-						length = ord(data[offset])
+						length = data[offset]
 						offset += 1
 						name = data[offset:offset + length]
-						name, old_sdk_version = name.split(':', 1)
+						name, old_sdk_version = name.split(b':', 1)
 
 						struct_fmt = b'I'
 						struct_size = struct.calcsize(struct_fmt)
@@ -1700,7 +1700,7 @@ with open(output_file_path_fixed, 'r+b') as f:
 						if old_sdk_version > new_sdk_version:
 							has_changes = True
 
-							data = data[:offset] + name + ':' + struct.pack(struct_fmt, new_sdk_version) + data[offset + length:]
+							data = data[:offset] + name + b':' + struct.pack(struct_fmt, new_sdk_version) + data[offset + length:]
 
 						offset += length
 


### PR DESCRIPTION
Thanks to @EchoStretch for telling it doesn't work on python3

```
python3 downgrade_elf3.py --input eboot.bin --sdk-version 05.050.001 --patch-memhole 1 --overwrite
/mnt/c/Users/Me/Downloads/eboot/downgrade_elf3.py:9: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  import distutils.dir_util
Input: ./eboot.bin
Output: ./eboot.bin
Dry Run: False
Verbose: False
Overwrite: True
Sdk Version: 05.050.001
Add _modded to Output: False
Patch Memory Hole: 1
Patch Memory Hole References: 001
Patch Memory Hole References Help: False
Patch Program Headers: True
Patch Dynamic Section: True
Patch Relocation Section: True
Patch Symbol Table: True
Patch Elf Header: True

processing elf file: ./eboot.bin

executable file detected
wanted sdk version: 05.050.001

searching for proc param segment
found param segment, parsing param structure
sdk version: 05.050.001
parsed param structure

found a memhole between: 0x0961c000 - 0x09800000 (not including the last address)

patching program headers

patched program headers

First Segment Virtual Address: 0x00000000

Segment Before Memory Hole Virtual Address: 0x09000000

Segment After Memory Hole Unmapped Virtual Address: 0x09800000
Segment After Memory Hole Mapped Virtual Address: 0x09800000
Segment After Memory Hole Memory Size: 0x001ba17c

searching for version segment
found version segment, parsing library list
detected the use of selfutil patched or unfself

patching sdk versions in library list
patched sdk versions in library list
parsed library list

patching elf header
patched elf header

finished patching: ./eboot.bin
```